### PR TITLE
replaced proc_macro_non_items with proc_macro_hygiene

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 ## Quickstart
 
 ```rust
-#![feature(proc_macro_non_items)]
+#![feature(proc_macro_hygiene)]
 
 extern crate eosio;
 

--- a/eosio/src/lib.rs
+++ b/eosio/src/lib.rs
@@ -1,7 +1,7 @@
 #![cfg_attr(feature = "alloc", feature(alloc))]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![feature(
-    proc_macro_non_items,
+    proc_macro_hygiene,
     try_from,
     custom_attribute,
     concat_idents

--- a/eosio/tests/bytes_tests.rs
+++ b/eosio/tests/bytes_tests.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro_non_items)]
+#![feature(proc_macro_hygiene)]
 
 extern crate eosio;
 

--- a/eosio_macros/src/lib.rs
+++ b/eosio_macros/src/lib.rs
@@ -1,6 +1,6 @@
 #![recursion_limit = "128"]
 #![feature(
-    proc_macro_non_items,
+    proc_macro_hygiene,
     proc_macro_diagnostic,
     proc_macro_quote
 )]

--- a/eosio_macros/tests/tests.rs
+++ b/eosio_macros/tests/tests.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro_non_items)]
+#![feature(proc_macro_hygiene)]
 
 extern crate eosio_macros;
 

--- a/examples/addressbook/src/lib.rs
+++ b/examples/addressbook/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro_non_items)]
+#![feature(proc_macro_hygiene)]
 
 extern crate eosio;
 

--- a/examples/eosio_token/src/lib.rs
+++ b/examples/eosio_token/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro_non_items)]
+#![feature(proc_macro_hygiene)]
 
 extern crate eosio;
 

--- a/examples/hello/src/lib.rs
+++ b/examples/hello/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro_non_items)]
+#![feature(proc_macro_hygiene)]
 
 extern crate eosio;
 

--- a/examples/tests/src/lib.rs
+++ b/examples/tests/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro_non_items)]
+#![feature(proc_macro_hygiene)]
 
 extern crate eosio;
 

--- a/examples/tictactoe/src/lib.rs
+++ b/examples/tictactoe/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro_non_items)]
+#![feature(proc_macro_hygiene)]
 
 extern crate eosio;
 


### PR DESCRIPTION
`proc_macro_non_items` is removed in nightly rust and replaced with `proc_macro_hygiene`.